### PR TITLE
Load scripts and styles in footer

### DIFF
--- a/classes/class-pronamic-cookies.php
+++ b/classes/class-pronamic-cookies.php
@@ -19,6 +19,7 @@ class Pronamic_Cookies {
 		add_action( 'template_redirect', array( $this, 'blocker' ) );
 
 		add_action( 'wp_footer', array( $this, 'show_message' ) );
+		add_action( 'wp_footer', array( $this, 'enqueue_style' ) );
 
 	}
 
@@ -28,11 +29,14 @@ class Pronamic_Cookies {
 
 	public function styles() {
 		wp_register_style( 'pronamic_cookie_style', plugins_url( PRONAMIC_CL_PLUGIN_DIR . '/assets/pronamic-cookie-law-style.css' ) );
+	}
+
+	public function enqueue_style() {
 		wp_enqueue_style( 'pronamic_cookie_style' );
 	}
 
 	public function scripts() {
-		wp_register_script( 'pronamic_cookie_js', plugins_url( PRONAMIC_CL_PLUGIN_DIR . '/assets/pronamic-cookie-law.js' ), array( 'jquery' ) );
+		wp_register_script( 'pronamic_cookie_js', plugins_url( PRONAMIC_CL_PLUGIN_DIR . '/assets/pronamic-cookie-law.js' ), array( 'jquery' ), false, true );
 		wp_enqueue_script( 'pronamic_cookie_js' );
 		
 		$setting_expire = get_option( 'pronamic_cookie_options_advanced_expires', '1 year' );


### PR DESCRIPTION
Changed wp_register_script and wp_register_style to load in the footer instead of the header. Helps improving website (page speed) performance.
